### PR TITLE
ownership transfer does not have deployer

### DIFF
--- a/deployment/3_deployContracts.js
+++ b/deployment/3_deployContracts.js
@@ -544,7 +544,8 @@ async function main() {
         );
 
         // Transfer ownership of the proxyAdmin to timelock
-        await upgrades.admin.transferProxyAdminOwnership(timelockContract.address);
+        const proxyAdminContract = proxyAdminFactory.attach(proxyAdminAddress);
+        await (await proxyAdminContract.transferOwnership(timelockContract.address)).wait();
     }
 
     if (committeeTimelock) {


### PR DESCRIPTION
The transferProxyAdminOwnership fails when you use a custom deployer.